### PR TITLE
Fix summary comment typo

### DIFF
--- a/InterviewPrep/WordWrap.cs
+++ b/InterviewPrep/WordWrap.cs
@@ -5,7 +5,7 @@ using System.Text;
 namespace InterviewPrep
 {
     /// <summary>
-    /// Give a long string, break it into lines that contain as many words as possible up to
+    /// Given a long string, break it into lines that contain as many words as possible up to
     /// a certain length. Concatenate words with a "-". If a single word is longer than the max
     /// wrap that word.
     /// </summary>


### PR DESCRIPTION
## Summary
- update the summary of `WordWrap` to say "Given" instead of "Give"

## Testing
- `dotnet build InterviewPrep/InterviewPrep.csproj -nologo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68883a555aa0832c9b93dae7a9ca99ea